### PR TITLE
Bump the maven-plugins group with 4 updates (#11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
 
     <!-- Use alternate plugins versions than what is in the spring-boot-starter-parent. -->
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
-    <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.3.1</maven-failsafe-plugin.version>
+    <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
+    <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
 


### PR DESCRIPTION
Bumps the maven-plugins group with 4 updates: [org.apache.maven.plugins:maven-deploy-plugin](https://github.com/apache/maven-deploy-plugin), [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire), [org.apache.maven.plugins:maven-install-plugin](https://github.com/apache/maven-install-plugin) and [org.apache.maven.plugins:maven-surefire-plugin](https://github.com/apache/maven-surefire).


Updates `org.apache.maven.plugins:maven-deploy-plugin` from 3.1.2 to 3.1.3
- [Release notes](https://github.com/apache/maven-deploy-plugin/releases)
- [Commits](https://github.com/apache/maven-deploy-plugin/compare/maven-deploy-plugin-3.1.2...maven-deploy-plugin-3.1.3)

Updates `org.apache.maven.plugins:maven-failsafe-plugin` from 3.3.1 to 3.4.0
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.4.0)

Updates `org.apache.maven.plugins:maven-install-plugin` from 3.1.2 to 3.1.3
- [Release notes](https://github.com/apache/maven-install-plugin/releases)
- [Commits](https://github.com/apache/maven-install-plugin/compare/maven-install-plugin-3.1.2...maven-install-plugin-3.1.3)

Updates `org.apache.maven.plugins:maven-surefire-plugin` from 3.3.1 to 3.4.0
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.4.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-deploy-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-plugins
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-minor dependency-group: maven-plugins
- dependency-name: org.apache.maven.plugins:maven-install-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-plugins
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-minor dependency-group: maven-plugins ...